### PR TITLE
Reset commit when specify commit hash

### DIFF
--- a/.github/workflows/create-release-and-publish-client.yml
+++ b/.github/workflows/create-release-and-publish-client.yml
@@ -1,4 +1,4 @@
-﻿name: Create Release and Publish package
+name: Create Release and Publish package
 
 on:
   workflow_dispatch:
@@ -86,8 +86,17 @@ jobs:
     needs: create-tag
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - name: Switch to commit
+        if: github.event.inputs.commit_hash != 'latest'
+        run: git reset $COMMIT_HASH --hard
+        env:
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
 
       - name: Check for open Pull requests
+        if: github.event.inputs.commit_hash == 'latest'
         run: |
           PULLS=$(gh api \
             -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
Add git reset command for creating and pushing binaries from the specified commit. Before this changes, tag and release was creating on commit from the past but binaries was built from the main HEAD. Solve this problem by adding git reset: now tag, release and binaries are creating from the specified commit